### PR TITLE
Pin docutils to the most recent version compatible with 3.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3==1.3.0
 botocore==1.4.10
 click==6.6
+docutils==0.15.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ packages = []
 
 setup_options = dict(
     name='dynq',
-    version='0.2.0',
+    version='0.2.1',
     description='Simple standalone DynamoDB client',
     author='Ray Holder',
     author_email='',


### PR DESCRIPTION
docutils >= 0.16 doesn't like python 3.4:
```shell
ERROR: docutils requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*' but the running Python is 3.4.3
```

This change simply sets the latest supported version in the `requirements`.

I suspect the real move is get this thing running on more recent versions of python but I think this is a necessary baby step towards that goal.